### PR TITLE
Ignore local registry files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea
 /*.iml
 /go-demo
+/docker/registry/


### PR DESCRIPTION
When the local registry container is started, it drops its data into the project directory.
The registry data should be ignored by git.